### PR TITLE
replace with marking_builtin

### DIFF
--- a/src/core/ast/tool/extract_config.h
+++ b/src/core/ast/tool/extract_config.h
@@ -4,6 +4,19 @@
 
 namespace brgen::ast::tool {
 
+    bool marking_builtin(const std::shared_ptr<ast::Expr>& node) {
+        if (auto memb = ast::as<ast::MemberAccess>(node)) {
+            auto bt = marking_builtin(memb->target);
+            if (bt) {
+                memb->member->usage = ast::IdentUsage::reference_builtin_fn;
+                return true;
+            }
+        }
+        if (auto spc = ast::as<ast::SpecialLiteral>(node)) {
+            return true;
+        }
+        return false;
+    }
     std::string extract_name(auto&& maybe_config, bool allow_ident = false) {
         if (!maybe_config) {
             return "";

--- a/src/core/ast/tool/stringer.h
+++ b/src/core/ast/tool/stringer.h
@@ -60,7 +60,7 @@ namespace brgen::ast::tool {
         }
     }
 
-    struct Stringer {
+        struct Stringer {
         using BinaryFunc = std::function<std::string(Stringer& s, const std::shared_ptr<Binary>& v)>;
         BinaryFunc bin_op_func;
         std::unordered_map<BinaryOp, BinaryFunc> bin_op_map;

--- a/src/core/middle/replace_order_spec.h
+++ b/src/core/middle/replace_order_spec.h
@@ -3,6 +3,7 @@
 #include <core/ast/traverse.h>
 #include <core/common/error.h>
 #include <core/ast/tool/extract_config.h>
+#include <core/ast/tool/extract_config.h>
 
 namespace brgen::middle {
     inline void replace_specify_order(const std::shared_ptr<ast::Node>& node) {
@@ -21,11 +22,7 @@ namespace brgen::middle {
                 return;
             }
             auto b = ast::cast_to<ast::Binary>(*it);
-            ast::as<ast::MemberAccess>(b->left)->member->usage = ast::IdentUsage::reference_builtin_fn;
-            if (a->name == "input.bit_order.mapping" ||
-                a->name == "input.bit_order.stream") {
-                ast::as<ast::MemberAccess>(ast::as<ast::MemberAccess>(b->left)->target)->member->usage = ast::IdentUsage::reference_builtin_fn;
-            }
+            ast::tool::marking_builtin(b->left);
             *it = std::make_shared<ast::SpecifyOrder>(std::move(b), std::move(a->arguments[0]),
                                                       a->name == "input.endian"             ? ast::OrderType::byte
                                                       : a->name == "input.bit_order"        ? ast::OrderType::bit_both

--- a/src/core/middle/resolve_import.h
+++ b/src/core/middle/resolve_import.h
@@ -88,7 +88,7 @@ namespace brgen::middle {
                 if (conf->arguments[0]->node_type != ast::NodeType::str_literal) {
                     error(conf->loc, "config.import() should take string literal but found ", ast::node_type_to_string(conf->arguments[0]->node_type)).report();
                 }
-                ast::as<ast::MemberAccess>(ast::as<ast::Call>(node)->callee)->member->usage = ast::IdentUsage::reference_builtin_fn;
+                ast::tool::marking_builtin(ast::cast_to<ast::Call>(node)->callee);
                 auto raw_path = ast::cast_to<ast::StrLiteral>(conf->arguments[0]);
                 auto path = unescape(raw_path->value);
                 if (!path) {

--- a/src/core/middle/resolve_io_operation.h
+++ b/src/core/middle/resolve_io_operation.h
@@ -82,7 +82,7 @@ namespace brgen::middle {
             else {
                 return;
             }
-            ast::as<ast::MemberAccess>(ast::as<ast::Call>(n)->callee)->member->usage = ast::IdentUsage::reference_builtin_fn;
+            ast::tool::marking_builtin(ast::as<ast::Call>(n)->callee);
             auto a = std::make_shared<ast::IOOperation>(ast::cast_to<ast::Expr>(std::move(n)), method);
             node.replace(std::move(a));
         };


### PR DESCRIPTION
フィールド引数のメタデータにおいて、ビルトイン判定がなかったので修正。