### PR TITLE
Gen/add auto set length

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,13 +55,14 @@
             "name": "Debug json2cpp",
             "type": "cppvsdbg",
             "request": "launch",
-            "program": "${workspaceRoot}/tool/json2vm",
+            "program": "${workspaceRoot}/tool/json2cpp2",
             "args": [
                 "ignore/sample.json",
-                "-r",
+                /*"-r",
                 "--call", "Test2.decode",
                 "--binary","example/vm_test/varint.dat",
                 "--hex",
+                */
             ],
             "stopAtEntry": false,
             "cwd": "${workspaceRoot}",

--- a/ast2go/gen/gen.go
+++ b/ast2go/gen/gen.go
@@ -391,15 +391,15 @@ func IsAnyRange(e ast2go.Node) bool {
 	return false
 }
 
-func IsOnAnonymousStruct(f *ast2go.Field) bool {
+func IsOnNamedStruct(f *ast2go.Field) bool {
 	s := f.BelongStruct
 	fmt, ok := f.Belong.(*ast2go.Format)
 	if ok {
-		return s != fmt.Body.StructType
+		return s == fmt.Body.StructType
 	}
 	state, ok := f.Belong.(*ast2go.State)
 	if ok {
-		return s != state.Body.StructType
+		return s == state.Body.StructType
 	}
 	return false
 }

--- a/src/core/ast/node/expr.h
+++ b/src/core/ast/node/expr.h
@@ -159,6 +159,16 @@ namespace brgen::ast {
         }
     };
 
+    // .. or ..=
+    constexpr bool is_any_range(auto&& e) {
+        if (e && e->node_type == NodeType::range) {
+            auto p = static_cast<ast::Range*>(std::to_address(e));
+
+            return !p->start && !p->end;
+        }
+        return false;
+    }
+
     struct MemberAccess : Expr {
         define_node_type(NodeType::member_access);
         std::shared_ptr<Expr> target;

--- a/src/core/ast/parse.h
+++ b/src/core/ast/parse.h
@@ -69,7 +69,6 @@ namespace brgen::ast {
 
         void add_to_struct(const std::shared_ptr<Member>& f) {
             f->belong_struct = current_struct_;
-            current_struct_->fields.push_back(f);
             if (auto field = ast::as<Field>(f)) {
                 for (auto it = current_struct_->fields.rbegin(); it != current_struct_->fields.rend(); it++) {
                     if (auto p = ast::as<Field>(*it)) {
@@ -78,6 +77,7 @@ namespace brgen::ast {
                     }
                 }
             }
+            current_struct_->fields.push_back(f);
         }
 
         size_t current_indent() {

--- a/src/core/ast/tool/type.h
+++ b/src/core/ast/tool/type.h
@@ -202,4 +202,17 @@ namespace brgen::ast::tool {
             }
         }
     }
+
+    bool is_on_named_struct(const std::shared_ptr<ast::Field>& field) {
+        if (!field) {
+            return false;
+        }
+        if (auto fmt = ast::as<ast::Format>(field->belong.lock())) {
+            return field->belong_struct.lock() == fmt->body->struct_type;
+        }
+        if (auto state = ast::as<ast::State>(field->belong.lock())) {
+            return field->belong_struct.lock() == state->body->struct_type;
+        }
+        return false;
+    }
 }  // namespace brgen::ast::tool

--- a/src/core/ast/tool/type.h
+++ b/src/core/ast/tool/type.h
@@ -83,7 +83,7 @@ namespace brgen::ast::tool {
                         if (!desc.ignore_if_not_match &&
                             ast::as<ast::VoidType>(f->field_type)) {
                             if (auto r = ast::as<ast::Range>(branch[i]->cond);
-                                r && !r->start && !r->end &&
+                                ast::is_any_range(r) &&
                                 r->op == ast::BinaryOp::range_exclusive) {
                                 desc.ignore_if_not_match = true;
                                 continue;

--- a/src/core/middle/typing.h
+++ b/src/core/middle/typing.h
@@ -613,7 +613,7 @@ namespace brgen::middle {
                         }
                     }
                 }
-                if (auto r = ast::as<ast::Range>(c->cond); r && !r->start && !r->end) {
+                if (ast::is_any_range(c->cond)) {
                     any_match = c->cond;
                 }
             }

--- a/src/tool/json2cpp2/generate.h
+++ b/src/tool/json2cpp2/generate.h
@@ -6,6 +6,7 @@
 #include <writer/writer.h>
 #include <core/ast/tool/stringer.h>
 #include <core/ast/tool/sort.h>
+#include <core/ast/tool/type.h>
 #include "../common/line_map.h"
 
 namespace j2cp2 {
@@ -297,6 +298,34 @@ namespace j2cp2 {
             w.writeln("}");
         }
 
+        std::shared_ptr<ast::Ident> has_ident_len(const std::shared_ptr<ast::Type>& typ) {
+            if (auto arr_ty = ast::as<ast::ArrayType>(typ);
+                arr_ty && !arr_ty->length_value) {
+                if (auto ident_len = ast::as<ast::Ident>(arr_ty->length)) {
+                    return ast::cast_to<ast::Ident>(arr_ty->length);
+                }
+            }
+            return nullptr;
+        }
+
+        void maybe_write_auto_length_set(std::string_view to_set, const std::shared_ptr<ast::Type>& typ) {
+            if (auto ident_len = has_ident_len(typ)) {
+                auto [base, _] = *ast::tool::lookup_base(ident_len);
+                if (auto f = ast::as<ast::Field>(base->base.lock())) {
+                    auto typ = get_type_name(f->field_type);
+                    w.writeln("if(", to_set, "> ~", typ, "(0)) {");
+                    {
+                        auto indent = w.indent_scope();
+                        w.writeln("return false;");
+                    }
+                    w.writeln("}");
+                    auto ident = str.to_string(f->ident);
+                    map_line(f->loc);
+                    w.writeln(ident, " = ", to_set, ";");
+                }
+            }
+        }
+
         void write_common_type_accessor(const std::string& cond_u, const std::shared_ptr<ast::Field>& uf, ast::UnionType* ut) {
             // write getter func
             map_line(uf->loc);
@@ -359,6 +388,7 @@ namespace j2cp2 {
                     map_line(f->loc);
                     set_variant_alternative(f->belong_struct.lock());
                     auto a = str.to_string(f->ident);
+                    maybe_write_auto_length_set("v.size()", f->field_type);
                     w.writeln(a, " = v;");
                     w.writeln("return true;");
                 };
@@ -570,6 +600,16 @@ namespace j2cp2 {
                     }
                 }
                 str.map_ident(f->ident, prefix, f->ident->ident);
+                if (auto ident = has_ident_len(type); ident && ast::tool::is_on_named_struct(f)) {
+                    w.writeln("bool set_", f->ident->ident, "(auto&& v) {");
+                    {
+                        auto indent = w.indent_scope();
+                        maybe_write_auto_length_set("v.size()", type);
+                        auto to = str.to_string(f->ident);
+                        w.writeln(to, " = std::forward<decltype(v)>(v);");
+                    }
+                    w.writeln("}");
+                }
             }
             if (auto struct_ty = ast::as<ast::StructType>(type)) {
                 auto type_name = get_type_name(type);

--- a/src/tool/json2cpp2/generate.h
+++ b/src/tool/json2cpp2/generate.h
@@ -488,7 +488,7 @@ namespace j2cp2 {
             std::vector<std::shared_ptr<ast::Field>>& non_aligned,
             size_t& bit_size,
             size_t i,
-            const std::shared_ptr<ast::StructType>& s,
+            // const std::shared_ptr<ast::StructType>& s,
             const std::shared_ptr<ast::Field>& f, std::string_view prefix) {
             futils::helper::DynDefer d;
             auto is_simple_type = [&](const std::shared_ptr<ast::Type>& type) {
@@ -565,13 +565,7 @@ namespace j2cp2 {
                     }
                     if (f->follow == ast::Follow::constant) {
                         auto& later = later_size[f.get()];
-                        for (auto j = i + 1; j < s->fields.size(); j++) {
-                            auto& f2 = s->fields[j];
-                            if (auto f2_ = ast::as<ast::Field>(f2); f2_) {
-                                later.next_field = ast::cast_to<ast::Field>(f2);
-                                break;
-                            }
-                        }
+                        later.next_field = f->next.lock();
                         assert(later.next_field);
                     }
                 }
@@ -608,7 +602,7 @@ namespace j2cp2 {
                 for (auto i = 0; i < s->fields.size(); i++) {
                     auto& field = s->fields[i];
                     if (auto f = ast::as<ast::Field>(field); f) {
-                        write_field(non_aligned, bit_size, i, s, ast::cast_to<ast::Field>(field), prefix);
+                        write_field(non_aligned, bit_size, i, ast::cast_to<ast::Field>(field), prefix);
                     }
                 }
                 if (has_ident) {
@@ -709,7 +703,7 @@ namespace j2cp2 {
                         w.write("else ");
                     }
                     // any match (`..`) case
-                    if (auto r = ast::as<ast::Range>(br->cond); r && !r->start && !r->end) {
+                    if (ast::is_any_range(br->cond)) {
                         // nothing to write
                         w.writeln("{");
                     }

--- a/src/tool/json2go/generate.go
+++ b/src/tool/json2go/generate.go
@@ -33,7 +33,7 @@ func init() {
 	})
 }
 
-func resetFlag() {
+func ResetFlag() {
 	*f = false
 	*filename = ""
 	*usePut = false
@@ -176,6 +176,26 @@ func (g *Generator) writeBitField(belong string, prefix string, fields []*ast2go
 	}
 }
 
+func (g *Generator) InsertOverflowCheck(target string, compareType string, limitType string) {
+	g.PrintfFunc("if %s > %s(^%s(0)) {\n", target, compareType, limitType)
+	g.PrintfFunc("return false\n")
+	g.PrintfFunc("}\n")
+}
+
+func (g *Generator) maybeWriteLengthSet(toSet string, length ast2go.Expr) {
+	ident, ok := length.(*ast2go.Ident)
+	if ok {
+		ident, _ := gen.LookupBase(ident)
+		f := ident.Base.(*ast2go.Field)
+		if f != nil {
+			setTo := g.exprStringer.ExprString(f.Ident)
+			typ := g.getType(f.FieldType)
+			g.InsertOverflowCheck(toSet, "int", typ)
+			g.PrintfFunc("%s = %s(%s)\n", setTo, typ, toSet)
+		}
+	}
+}
+
 func (g *Generator) writeStructUnion(belong string, prefix string, u *ast2go.StructUnionType) {
 	for _, v := range u.Structs {
 		seq := g.getSeq()
@@ -261,9 +281,9 @@ func (g *Generator) writeStructUnion(belong string, prefix string, u *ast2go.Str
 						s := g.exprStringer.ExprString(c.Field.Ident)
 						fieldType := g.getType(c.Field.FieldType)
 						if fieldType != typStr && c.Field.FieldType.GetNodeType() == ast2go.NodeTypeIntType {
-							g.PrintfFunc("if v > %s(^%s(0)) {\n", typStr, fieldType)
-							g.PrintfFunc("return false\n")
-							g.PrintfFunc("}\n")
+							g.InsertOverflowCheck("v", typStr, fieldType)
+						} else if arr, ok := c.Field.FieldType.(*ast2go.ArrayType); ok {
+							g.maybeWriteLengthSet("len(v)", arr.Length)
 						}
 						g.PrintfFunc("%s = %s(v)\n", s, fieldType)
 						g.PrintfFunc("return true\n")
@@ -313,7 +333,7 @@ func (g *Generator) writeStructType(belong string, prefix string, s *ast2go.Stru
 		is_simple         = true
 		size       uint64 = 0
 	)
-	for i, v := range s.Fields {
+	for _, v := range s.Fields {
 		if field, ok := v.(*ast2go.Field); ok {
 			if field.BitAlignment == ast2go.BitAlignmentNotTarget {
 				continue
@@ -364,17 +384,16 @@ func (g *Generator) writeStructType(belong string, prefix string, s *ast2go.Stru
 				g.exprStringer.SetIdentMap(field.Ident, "%s"+field.Ident.Ident)
 				if _, ok := arr_type.Length.(*ast2go.Range); ok {
 					if field.EventualFollow == ast2go.FollowEnd {
-						size := uint64(0)
-						for k := i + 1; k < len(s.Fields); k++ {
-							if f, ok := s.Fields[k].(*ast2go.Field); ok {
-								if f.BitAlignment == ast2go.BitAlignmentNotTarget {
-									continue
-								}
-								size += *f.FieldType.GetBitSize()
-							}
-						}
-						g.laterSize[field] = size
+						g.laterSize[field] = field.BelongStruct.FixedTailSize
 					}
+				}
+				if !gen.IsOnAnonymousStruct(field) && arr_type.LengthValue == nil && !gen.IsAnyRange(arr_type.Length) {
+					s := g.exprStringer.ExprString(field.Ident)
+					g.PrintfFunc("func (t *%s) Set%s(v %s) bool {\n", belong, field.Ident.Ident, typ)
+					g.maybeWriteLengthSet("len("+s+")", arr_type.Length)
+					g.PrintfFunc("%s = v\n", s)
+					g.PrintfFunc("return true\n")
+					g.PrintfFunc("}\n")
 				}
 			}
 			if i_type, ok := typ.(*ast2go.IntType); ok {
@@ -621,6 +640,7 @@ func (g *Generator) writeFieldDecode(p *ast2go.Field) {
 			g.PrintfFunc("if len_%s != 0 {\n", p.Ident.Ident)
 			g.PrintfFunc("tmp%s := make([]byte, len_%s)\n", p.Ident.Ident, p.Ident.Ident)
 			g.PrintfFunc("n_%s, err := io.ReadFull(r,tmp%s[:])\n", p.Ident.Ident, p.Ident.Ident)
+			g.PrintfFunc("if err != nil {\n")
 			g.PrintfFunc("if err == io.ErrUnexpectedEOF || n_%s != len_%s /*stdlib bug?*/ {\n", p.Ident.Ident, p.Ident.Ident)
 			g.imports["fmt"] = struct{}{}
 			g.PrintfFunc("return fmt.Errorf(\"read %s: %%w: expect %%d bytes but read %%d bytes\",io.ErrUnexpectedEOF, n_%s, len_%s)\n", p.Ident.Ident, p.Ident.Ident, p.Ident.Ident)
@@ -688,33 +708,36 @@ func (g *Generator) writeIf(if_ *ast2go.If, enc bool) {
 func (g *Generator) writeMatch(m *ast2go.Match, enc bool) {
 	g.PrintfFunc("switch %s {\n", g.exprStringer.ExprString(m.Cond))
 	for _, mb := range m.Branch {
-		g.PrintfFunc("case %s:\n", g.exprStringer.ExprString(mb.Cond))
+		if gen.IsAnyRange(mb.Cond) {
+			g.PrintfFunc("default:\n")
+		} else {
+			g.PrintfFunc("case %s:\n", g.exprStringer.ExprString(mb.Cond))
+		}
 		g.writeSingleNode(mb.Then, enc)
 	}
 	g.PrintfFunc("}\n")
 }
 
 func (g *Generator) writeSingleNode(node ast2go.Node, enc bool) {
-	switch node.GetNodeType() {
-	case ast2go.NodeTypeIndentBlock:
-		indentBlock := node.(*ast2go.IndentBlock)
-		for _, elem := range indentBlock.Elements {
+	switch n := node.(type) {
+	case *ast2go.IndentBlock:
+		for _, elem := range n.Elements {
 			g.writeSingleNode(elem, enc)
 		}
-	case ast2go.NodeTypeIf:
-		g.writeIf(node.(*ast2go.If), enc)
-	case ast2go.NodeTypeMatch:
-		g.writeMatch(node.(*ast2go.Match), enc)
-	case ast2go.NodeTypeField:
+	case *ast2go.If:
+		g.writeIf(n, enc)
+	case *ast2go.Match:
+		g.writeMatch(n, enc)
+	case *ast2go.Field:
 		if enc {
-			g.writeFieldEncode(node.(*ast2go.Field))
+			g.writeFieldEncode(n)
 		} else {
-			g.writeFieldDecode(node.(*ast2go.Field))
+			g.writeFieldDecode(n)
 		}
-	case ast2go.NodeTypeScopedStatement:
-		g.writeSingleNode(node.(*ast2go.ScopedStatement).Statement, enc)
-	case ast2go.NodeTypeBinary:
-		binary := node.(*ast2go.Binary)
+	case *ast2go.ScopedStatement:
+		g.writeSingleNode(n.Statement, enc)
+	case *ast2go.Binary:
+		binary := n
 		if binary.Op == ast2go.BinaryOpDefineAssign ||
 			binary.Op == ast2go.BinaryOpConstAssign {
 			ident := binary.Left.(*ast2go.Ident)
@@ -855,7 +878,7 @@ func (g *Generator) Generate(file *ast2go.AstFile) error {
 	g.exprStringer.Receiver = "t."
 	g.exprStringer.BinaryMapper[ast2go.BinaryOpEqual] = func(s *gen.ExprStringer, x, y ast2go.Expr) string {
 		if r, ok := y.(*ast2go.Range); ok {
-			if r.Start == nil && r.End == nil {
+			if gen.IsAnyRange(r) {
 				return "true" // compare with .. or ..= is always true
 			}
 			rty := r.ExprType.(*ast2go.RangeType)

--- a/src/tool/json2go/generate.go
+++ b/src/tool/json2go/generate.go
@@ -387,7 +387,7 @@ func (g *Generator) writeStructType(belong string, prefix string, s *ast2go.Stru
 						g.laterSize[field] = field.BelongStruct.FixedTailSize
 					}
 				}
-				if !gen.IsOnAnonymousStruct(field) && arr_type.LengthValue == nil && !gen.IsAnyRange(arr_type.Length) {
+				if gen.IsOnNamedStruct(field) && arr_type.LengthValue == nil && !gen.IsAnyRange(arr_type.Length) {
 					s := g.exprStringer.ExprString(field.Ident)
 					g.PrintfFunc("func (t *%s) Set%s(v %s) bool {\n", belong, field.Ident.Ident, typ)
 					g.maybeWriteLengthSet("len("+s+")", arr_type.Length)

--- a/src/tool/json2go/js.go
+++ b/src/tool/json2go/js.go
@@ -52,7 +52,7 @@ func setFunc() {
 			result["code"] = 1
 			return result
 		}
-		resetFlag()
+		ResetFlag()
 		err := flag.CommandLine.Parse(cmdargs[1:])
 		if err != nil {
 			result["stderr"] = err.Error()

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -270,8 +270,7 @@ namespace brgen::vm {
                 op(Op::LOAD_IMMEDIATE, *arr_ty->length_value);
                 op(Op::READ_BYTES);
             }
-            else if (auto l = ast::as<ast::Range>(arr_ty->length);
-                     l && !l->start && !l->end) {
+            else if (ast::is_any_range(arr_ty->length)) {
                 if (!f) {
                     auto index = add_static(Value{futils::view::rvec("error: array length is not decidable")});
                     op(Op::LOAD_STATIC, index);
@@ -309,8 +308,7 @@ namespace brgen::vm {
 
         void compile_complex_array(const std::shared_ptr<ast::Field>& f, ast::ArrayType* arr_ty) {
             auto elm = arr_ty->element_type;
-            if (auto l = ast::as<ast::Range>(arr_ty->length);
-                l && !l->start && !l->end) {
+            if (ast::is_any_range(arr_ty->length)) {
                 if (!f) {
                     auto index = add_static(Value{futils::view::rvec("error: array length is not decidable")});
                     op(Op::LOAD_STATIC, index);
@@ -541,7 +539,7 @@ namespace brgen::vm {
                 op(Op::PUSH, 0);  // push register 0 to stack
                 std::vector<size_t> jump;
                 for (auto& br : match->branch) {
-                    if (auto any = ast::as<ast::Range>(br->cond); any && !any->start && !any->end) {
+                    if (ast::is_any_range(br->cond)) {
                         compile_node(fmt, br->then);
                         jump.push_back(op(Op::JMP));
                     }


### PR DESCRIPTION
C++とGo版に動的配列をセットするとき同時に長さもセットするやつを追加(単純な関係の場合のみ)