### PR TITLE
ci: parallelize unictest by runner via dynamic matrix

### DIFF
--- a/.github/workflows/unictest.yaml
+++ b/.github/workflows/unictest.yaml
@@ -9,9 +9,27 @@ permissions:
   contents: read
 
 jobs:
-  unictest-linux:
+  list-runners:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      runners: ${{ steps.list.outputs.runners }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: List runners
+        id: list
+        working-directory: rebrgen
+        run: echo "runners=$(python script/list_unictest_runners.py)" >> "$GITHUB_OUTPUT"
+
+  unictest-shard:
+    needs: list-runners
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJSON(needs.list-runners.outputs.runners) }}
     steps:
       - name: Timeline
         uses: Kesin11/actions-timeline@e018cfefea60b4f44266998551211a35a58b8097 # v3.0.0
@@ -50,12 +68,34 @@ jobs:
           cd rebrgen
           chmod -R +x tool/
           cp build_config.template.json build_config.json
-          python script/unictest.py --print-stdout --output-json test_results.json || true
-          cd ..
-          mkdir -p test_results
-          mv rebrgen/test_results.json test_results/
-          cp script/unictest_result.html test_results/index.html
+          python script/unictest.py --print-stdout --target-runner ${{ matrix.runner }} --output-json test_results.json || true
+      - name: Upload shard result
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v8.0.0
+        with:
+          name: unictest-shard-${{ matrix.runner }}
+          path: rebrgen/test_results.json
 
+  unictest-merge:
+    needs: unictest-shard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Timeline
+        uses: Kesin11/actions-timeline@e018cfefea60b4f44266998551211a35a58b8097 # v3.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Download shard results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: unictest-shard-*
+          path: shards
+      - name: Merge results
+        run: |
+          mkdir -p test_results
+          python rebrgen/script/merge_unictest_results.py shards test_results/test_results.json
+          cp script/unictest_result.html test_results/index.html
       - name: Upload test results
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v8.0.0
         with:

--- a/.github/workflows/unictest.yaml
+++ b/.github/workflows/unictest.yaml
@@ -68,7 +68,7 @@ jobs:
           cd rebrgen
           chmod -R +x tool/
           cp build_config.template.json build_config.json
-          python script/unictest.py --print-stdout --target-runner ${{ matrix.runner }} --output-json test_results.json || true
+          python script/unictest.py --print-stdout --target-runner ${{ matrix.runner }} --parallel-limit 0 --output-json test_results.json || true
       - name: Upload shard result
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v8.0.0
         with:

--- a/rebrgen/script/list_unictest_runners.py
+++ b/rebrgen/script/list_unictest_runners.py
@@ -1,0 +1,37 @@
+"""Emit the runner names declared in ``test/unictest.json`` as a JSON array.
+
+Used by CI to build a dynamic matrix without hard-coding the language list.
+The runner name is read from each referenced ``unictest_runner.json`` file so
+we stay robust against directory renames.
+"""
+import json
+import pathlib as pl
+import sys
+
+DEFAULT_CONFIG = pl.Path("test/unictest.json")
+
+
+def resolve_file(entry_file: str, work_dir: pl.Path) -> pl.Path:
+    return pl.Path(entry_file.replace("$WORK_DIR", str(work_dir))).resolve()
+
+
+def main() -> int:
+    config_path = pl.Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_CONFIG
+    work_dir = config_path.resolve().parent.parent
+
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = json.load(f)
+
+    names = []
+    for entry in config.get("runners", []):
+        runner_file = resolve_file(entry["file"], work_dir)
+        with open(runner_file, "r", encoding="utf-8") as f:
+            runner = json.load(f)
+        names.append(runner["name"])
+
+    json.dump(names, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/rebrgen/script/merge_unictest_results.py
+++ b/rebrgen/script/merge_unictest_results.py
@@ -1,0 +1,64 @@
+"""Merge per-runner unictest result JSONs produced by the sharded CI pipeline.
+
+Each shard writes a ``test_results.json`` with the schema declared in
+``src/tool/unictest/src/main.rs::TestResults``. We concatenate ``results`` and
+``setup_failures`` across shards and recompute the aggregate counts so the
+downstream consumer (``unictest_result.html`` etc.) sees a single merged file
+indistinguishable from a non-sharded run.
+"""
+import json
+import pathlib as pl
+import sys
+
+
+def merge(shard_paths: list[pl.Path]) -> dict:
+    results = []
+    setup_failures = []
+    for path in shard_paths:
+        with open(path, "r", encoding="utf-8") as f:
+            shard = json.load(f)
+        results.extend(shard.get("results", []))
+        setup_failures.extend(shard.get("setup_failures", []))
+
+    fail_count = sum(1 for r in results if not r.get("success"))
+    return {
+        "success_count": len(results) - fail_count,
+        "fail_count": fail_count,
+        "setup_fail_count": len(setup_failures),
+        "setup_failures": setup_failures,
+        "results": results,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(
+            "usage: merge_unictest_results.py <shard_dir> <output_json>",
+            file=sys.stderr,
+        )
+        return 2
+
+    shard_dir = pl.Path(sys.argv[1])
+    output_path = pl.Path(sys.argv[2])
+
+    shard_paths = sorted(shard_dir.rglob("test_results.json"))
+    if not shard_paths:
+        print(f"no shard results found under {shard_dir}", file=sys.stderr)
+        return 1
+
+    merged = merge(shard_paths)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(merged, f, indent=2)
+
+    print(
+        f"merged {len(shard_paths)} shards -> {output_path} "
+        f"(pass={merged['success_count']}, fail={merged['fail_count']}, "
+        f"setup_fail={merged['setup_fail_count']})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- `unictest.yaml` を list-runners → matrix shard → merge の3 job 構成に書き換え、GA job を言語単位で並列化
- 言語一覧は `rebrgen/test/unictest.json` から動的生成するため、runner 追加時は workflow 無改修で自動追従
- shard 結果を `rebrgen/script/merge_unictest_results.py` で集約、既存の `unictest-results` artifact と互換（`build-pages` 側は無改修）

## Test plan
- [ ] Actions 上で `list-runners` が 12 ランナー分の JSON 配列を出す
- [ ] matrix 展開で `unictest-shard (ebm2<lang>)` が言語ごとに並列起動する
- [ ] 各 shard が `test_results.json` を artifact として upload する
- [ ] `unictest-merge` が全 shard をダウンロードして `test_results.json` + `index.html` を同梱した `unictest-results` を出力する
- [ ] 後続 `build-pages` が従来通り `unictest-results` を展開できる