### PR TITLE
sample: add dtls_record/mbr/gpt/mavlink_v2/ac3

### DIFF
--- a/example/dtls_record.bgn
+++ b/example/dtls_record.bgn
@@ -1,0 +1,29 @@
+# source: RFC 6347 §4.1 — Datagram Transport Layer Security Version 1.2 (https://datatracker.ietf.org/doc/html/rfc6347)
+# scope: DTLS 1.2 record-layer envelope (DTLSPlaintext / DTLSCiphertext share layout): ContentType + ProtocolVersion + Epoch + 48-bit Sequence Number + Length + length-prefixed fragment
+# out-of-scope: handshake message reassembly fields (DTLSHandshake message_seq / fragment_offset / fragment_length; RFC 6347 §4.2.2), record-layer encryption containers (GenericBlockCipher / GenericAEADCipher), DTLS 1.3 unified header with bit-mask record number (RFC 9147), HelloVerifyRequest cookie exchange, retransmission/timer state, Path MTU discovery
+# note: All multi-byte integers are BIG-ENDIAN (network byte order). DTLS 1.2 ProtocolVersion is the bit-inverted form of TLS 1.2: 0xFEFD = ~0x0102. The on-wire `epoch` field carries the epoch counter (incremented after each ChangeCipherSpec) and is REDUNDANT with the upper 16 bits of the receiver's reconstructed sequence-number space — it lets a receiver pick the right keying epoch without trial-decrypting. Heartbeat ContentType (24) was added later by RFC 6520.
+config.url = "https://datatracker.ietf.org/doc/html/rfc6347"
+
+enum DTLSContentType:
+    :u8
+    invalid = 0
+    change_cipher_spec = 20
+    alert = 21
+    handshake = 22
+    application_data = 23
+    heartbeat = 24
+
+enum DTLSVersion:
+    :u16
+    invalid = 0
+    dtls10 = 0xFEFF
+    dtls12 = 0xFEFD
+
+format DTLSPlaintext:
+    # RFC 6347 §4.1 envelope. DTLSCiphertext shares this exact 13-byte fixed header; the body just becomes ciphertext.
+    type :DTLSContentType
+    version :DTLSVersion
+    epoch :u16
+    sequence_number :u48
+    length :u16
+    fragment :[length]u8

--- a/example/filesystem/gpt.bgn
+++ b/example/filesystem/gpt.bgn
@@ -1,0 +1,39 @@
+# source: UEFI Specification 2.10 §5.3 GPT Disk Layout (https://uefi.org/specifications), cross-referenced with Wikipedia "GUID Partition Table"
+# scope: GPT primary header (LBA1, 92 bytes) + GPT Partition Entry struct (128-byte minimum width per spec)
+# out-of-scope: Backup GPT header at LBA -1 (identical layout, role swap of CurrentLBA / BackupLBA so each header points at the other), partition entry CRC re-computation procedure, the mixed-endian display rule of disk_guid / partition_type_guid / unique_partition_guid (the first three GUID groups are LE on wire, only stringified in canonical mixed-endian form), known partition type GUIDs and attribute bit 60/62/63 semantics, hybrid MBR negotiation, EFI System Partition contents, EFI Boot Variables
+# note: All multi-byte integers are LITTLE-ENDIAN. The 8-byte signature on wire is the ASCII text "EFI PART" (0x45 0x46 0x49 0x20 0x50 0x41 0x52 0x54), which equals 0x5452415020494645 when read as a little-endian u64. header_crc32 is computed over header_size bytes with that field zeroed during compute. partition_entries_crc32 is computed over (num_partition_entries * size_partition_entry) bytes of the entry array. partition_name is 36 UTF-16LE code units (72 bytes) padded with U+0000.
+config.url = "https://uefi.org/specifications"
+input.endian = config.endian.little
+
+GPT_SIGNATURE ::= 0x5452415020494645
+GPT_REVISION_1_0 ::= 0x00010000
+
+format GptHeader:
+    # §5.3.2 EFI_PARTITION_TABLE_HEADER. Lives at LBA1 (typically byte offset 0x200 for 512-byte sectors).
+    signature :u64
+    signature == GPT_SIGNATURE
+    revision :u32                            # 0x00010000 = revision 1.0
+    header_size :u32                         # MUST be >= 92 and <= block size; typically 92
+    header_size >= 92
+    header_crc32 :u32                        # CRC32 over header_size bytes with this field zeroed
+    reserved :u32
+    reserved == 0
+    current_lba :u64                         # LBA of this header copy
+    backup_lba :u64                          # LBA of the alternate (backup) GPT header
+    first_usable_lba :u64
+    last_usable_lba :u64
+    disk_guid :[16]u8
+    partition_entries_lba :u64               # typically 2 for a primary header
+    num_partition_entries :u32               # typically 128
+    size_partition_entry :u32                # MUST be a power of 2 and >= 128; typically 128
+    partition_entries_crc32 :u32
+
+format GptPartitionEntry:
+    # §5.3.3 EFI_PARTITION_ENTRY. size_partition_entry from the header is the per-disk authoritative width;
+    # 128 bytes is the spec-mandated minimum and the universal current value.
+    partition_type_guid :[16]u8              # all-zero = unused entry
+    unique_partition_guid :[16]u8
+    starting_lba :u64
+    ending_lba :u64                          # inclusive
+    attributes :u64                          # bit 0 = RequiredPartition, bit 1 = NoBlockIOProtocol, bit 60 = ReadOnly, bit 62 = Hidden, bit 63 = NoDriveLetter; type-specific bits 48..63
+    partition_name :[72]u8                   # 36 UTF-16LE code units, U+0000 padded

--- a/example/filesystem/mbr.bgn
+++ b/example/filesystem/mbr.bgn
@@ -1,0 +1,34 @@
+# source: Wikipedia "Master boot record" (https://en.wikipedia.org/wiki/Master_boot_record), cross-referenced with widely deployed disk-tool implementations
+# scope: Classic 512-byte MBR sector (LBA 0): 446-byte bootstrap-code area, 4×16-byte partition-table entries with CHS + LBA dual addressing, 0xAA55 boot signature; partition entry struct exposed as a top-level format
+# out-of-scope: Extended Boot Record (EBR) chain for logical partitions inside an extended primary (type 0x05 / 0x0F), Modern MBR variants embedding a 4-byte disk signature + 2 reserved bytes at offset 0x01B8..0x01BD which truncates the bootstrap-code area to 440 bytes, Advanced Active Partition / AAP / AST tweaks, the boot-loader handoff convention, GPT protective-MBR semantics (single 0xEE entry covering the disk)
+# note: All multi-byte integers are LITTLE-ENDIAN. CHS fields are LEGACY and are commonly clamped to 0xFE 0xFF 0xFF when the geometry exceeds the 8-GiB CHS limit; modern kernels rely on lba_start / lba_sectors. Within byte 1 of MbrChsAddress the upper 2 bits hold the high cylinder bits and the lower 6 bits hold the sector-within-track value (1-based). The on-wire u16 at offset 0x01FE reads 0xAA55 (raw bytes 0x55 0xAA in disk order).
+config.url = "https://en.wikipedia.org/wiki/Master_boot_record"
+input.endian = config.endian.little
+
+enum MbrPartitionStatus:
+    :u8
+    inactive = 0x00
+    active = 0x80
+
+format MbrChsAddress:
+    # 24-bit packed CHS. byte 0 = head (8 bits); byte 1 = cylinder_high(2) | sector(6) MSB-first; byte 2 = cylinder_low (8 bits).
+    head :u8
+    cylinder_high :u2
+    sector :u6
+    cylinder_low :u8
+
+format MbrPartitionEntry:
+    # 16-byte partition-table entry (4 entries × 16 bytes = 64 bytes total).
+    status :MbrPartitionStatus
+    first_chs :MbrChsAddress
+    partition_type :u8                       # 0x00=empty, 0x07=NTFS/exFAT, 0x0B=FAT32-CHS, 0x0C=FAT32-LBA, 0x83=Linux, 0x82=Linux swap, 0xEE=GPT-protective, 0xEF=EFI-System (legacy)
+    last_chs :MbrChsAddress
+    lba_start :u32                           # absolute first LBA of the partition; 0 if unused
+    lba_sectors :u32                         # length in 512-byte sectors
+
+format MbrSector:
+    # 446 + 64 + 2 = 512 bytes
+    bootstrap_code :[446]u8
+    partition_table :[4]MbrPartitionEntry
+    boot_signature :u16
+    boot_signature == 0xAA55

--- a/example/media/ac3.bgn
+++ b/example/media/ac3.bgn
@@ -1,0 +1,72 @@
+# source: ATSC A/52:2018 Digital Audio Compression (AC-3, E-AC-3) Standard (https://www.atsc.org/atsc-documents/a522018-digital-audio-compression-ac-3-e-ac-3-standard/, fetched 2026-04-29) §5.3 SyncInfo + §5.4 Bit Stream Information
+# scope: AC-3 (Dolby Digital) elementary-stream syncframe header — syncinfo + bsi up to and including the addbsi extension area, with conditional fields gated by acmod (cmixlev / surmixlev / dsurmod), the dual-mono (acmod==0) duplicated dialnorm/compr/langcod/audprodi block, copyrightb / origbs flags, the two timecode fields, and the addbsi extension
+# out-of-scope: The audblk[] PCM-block syntax (auditk[5] each carrying dynrng / cplstre / cplexpstr / chexpstr / cplbap / mantissas / etc.), the auxdata field, the trailing crc2 (24-bit at the very end of the frame), bit-rate / sample-rate decoding tables (frmsizecod → frame-size-in-words is a separate spec-defined lookup), Annex E (E-AC-3 / DD+) extensions which use bsid==16 and a different syncframe layout, channel coupling and rematrixing details, the Lossless AC-3 extension stream
+# note: AC-3 syncframes are a BIG-ENDIAN MSB-first bit stream (the brgen default). syncword is 0x0B77 (16 bits). bsid identifies the original AC-3 spec when 0..8; bsid==16 indicates the E-AC-3 / Dolby Digital Plus dialect (out-of-scope here). frmsizecod combined with fscod indexes a frame-size-in-16-bit-words lookup table. dialnorm value 0 is reserved (decoder must clamp to -31 dB if encountered). cmixlev is present only when acmod has a center channel (acmod & 0x01) AND acmod is not pure mono (acmod != 0x01). surmixlev is present iff acmod has surround channels (acmod & 0x04). dsurmod indicates the Dolby Surround encode flag for 2/0 stereo only (acmod == 0x02). For dual-mono (acmod == 0x00) a SECOND dialnorm/compr/langcod/audprodi block follows the first to describe channel 2 independently. addbsil on wire is "length minus one", so addbsil==0 means a 1-byte addbsi.
+config.url = "https://www.atsc.org/atsc-documents/a522018-digital-audio-compression-ac-3-e-ac-3-standard/"
+
+AC3_SYNCWORD ::= 0x0B77
+
+format Ac3SyncInfo:
+    # §5.3 syncinfo — fixed 5 bytes (40 bits)
+    syncword :u16
+    syncword == AC3_SYNCWORD
+    crc1 :u16                                # 16-bit CRC over the first 5/8 of the frame; reset for each frame
+    fscod :u2                                # 0=48kHz, 1=44.1kHz, 2=32kHz, 3=reserved
+    frmsizecod :u6                           # frame-size code; selects bytes-per-frame from a fscod-dependent table
+
+format Ac3AudProdInfo:
+    # Sub-block reused by both the primary and the dual-mono secondary audprodi blocks.
+    mixlevel :u5                             # peak SPL during mix in dB above 80 SPL (0..31 → 80..111 dB SPL)
+    roomtyp :u2                              # 0=not indicated, 1=large room flat-monitor, 2=small room flat-monitor, 3=reserved
+
+format Ac3Bsi:
+    # §5.4 bsi — variable-length bit-packed sequence following syncinfo.
+    bsid :u5                                 # 0..8 = original AC-3, 16 = E-AC-3 / DD+ (out-of-scope here)
+    bsmod :u3                                # bit-stream mode (main complete, music+effects, hearing-impaired, etc.)
+    acmod :u3                                # audio coding mode (0=1+1 dual-mono, 1=mono, 2=stereo, 3=3/0, 4=2/1, 5=3/1, 6=2/2, 7=3/2)
+    if (acmod & 0x01) != 0 && acmod != 0x01:
+        cmixlev :u2                          # center-channel mix level (0=-3dB, 1=-4.5dB, 2=-6dB, 3=reserved)
+    if (acmod & 0x04) != 0:
+        surmixlev :u2                        # surround mix level (0=-3dB, 1=-6dB, 2=mute, 3=reserved)
+    if acmod == 0x02:
+        dsurmod :u2                          # Dolby Surround encode flag for 2/0 stereo (0=not indicated, 1=not Dolby Surround, 2=Dolby Surround, 3=reserved)
+    lfeon :u1                                # low-frequency-effects channel present
+    dialnorm :u5                             # dialog normalization level for ch1 (-31..-1 dB; 0 reserved)
+    compre :u1
+    if compre == 1:
+        compr :u8                            # compression gain word for ch1
+    langcode :u1
+    if langcode == 1:
+        langcod :u8                          # language code byte for ch1 (deprecated; ISO 639-2 byte by convention)
+    audprodie :u1
+    if audprodie == 1:
+        audprodi :Ac3AudProdInfo
+    if acmod == 0x00:
+        # Dual-mono — duplicate the dialnorm / compr / langcod / audprodi block for channel 2.
+        dialnorm2 :u5
+        compr2e :u1
+        if compr2e == 1:
+            compr2 :u8
+        langcod2e :u1
+        if langcod2e == 1:
+            langcod2 :u8
+        audprodi2e :u1
+        if audprodi2e == 1:
+            audprodi2 :Ac3AudProdInfo
+    copyrightb :u1                           # copyright-asserted flag
+    origbs :u1                               # 1 = original bitstream, 0 = copy
+    timecod1e :u1                            # first timecode field present
+    if timecod1e == 1:
+        timecod1 :u14                        # high portion of timecode
+    timecod2e :u1                            # second timecode field present
+    if timecod2e == 1:
+        timecod2 :u14                        # low portion of timecode
+    addbsie :u1                              # additional bsi data present
+    if addbsie == 1:
+        addbsil :u6                          # length-minus-one (so on-wire 0 means 1 byte of addbsi)
+        addbsi :[addbsil + 1]u8
+
+format Ac3Syncframe:
+    # The full AC-3 syncframe header up to (but not including) the audblk[] payload.
+    syncinfo :Ac3SyncInfo
+    bsi :Ac3Bsi

--- a/example/net/mavlink_v2.bgn
+++ b/example/net/mavlink_v2.bgn
@@ -1,0 +1,31 @@
+# source: MAVLink Serialization spec v2.0 (https://mavlink.io/en/guide/serialization.html, fetched 2026-04-29)
+# scope: MAVLink v2 packet on-wire framing — STX + len + incompat_flags + compat_flags + seq + sysid + compid + 24-bit msgid + length-prefixed payload + 16-bit CRC + optional 13-byte signature gated by incompat_flags bit 0
+# out-of-scope: MAVLink v1 packet (STX 0xFE, no flags, 8-bit msgid, no signing), per-message payload field layout (depends on the dialect XML and the message extensions area), payload truncation rules (trailing zero bytes are stripped on transmit and re-zero-padded on receive — applies to v1 and v2), CRC_EXTRA seed byte for the X.25 / "CRC-16/MCRF4XX" CRC (dialect-defined per msgid), MAVLink signing key management and timestamp-replay-window logic
+# note: All multi-byte integers are LITTLE-ENDIAN. STX for v2 is 0xFD (v1 was 0xFE). msgid is a 3-byte little-endian unsigned integer occupying that exact width on wire (no 4-byte padding). checksum is CRC-16/MCRF4XX over [len, incompat_flags, compat_flags, seq, sysid, compid, msgid(3 bytes), payload..., CRC_EXTRA(1 byte appended only at compute time, NOT on wire)]. The signature is present iff (incompat_flags & 0x01) != 0; total = link_id(1) + timestamp(6 LE, 10µs ticks since 2015-01-01 00:00 UTC) + sig(6 truncated SHA-256-HMAC bytes).
+config.url = "https://mavlink.io/en/guide/serialization.html"
+input.endian = config.endian.little
+
+MAVLINK_V2_STX ::= 0xFD
+MAVLINK_V2_INCOMPAT_FLAG_SIGNED ::= 0x01
+
+format MavlinkV2Signature:
+    # §Message Signing — present iff incompat_flags bit 0 is set. 13 bytes total.
+    link_id :u8                              # link-namespace tag, scopes the replay window
+    timestamp :u48                           # 10µs ticks since 2015-01-01 00:00 UTC
+    signature :[6]u8                         # truncated SHA-256-HMAC, raw bytes
+
+format MavlinkV2Packet:
+    # §Packet format. Fixed framing = 12 bytes (STX..msgid + CRC) + payload + optional 13-byte signature.
+    stx :u8
+    stx == MAVLINK_V2_STX
+    len :u8                                  # payload length 0..255
+    incompat_flags :u8
+    compat_flags :u8
+    seq :u8                                  # rolling sequence number per (sysid, compid) pair
+    sysid :u8                                # 0 reserved by convention for broadcast
+    compid :u8
+    msgid :u24
+    payload :[len]u8
+    checksum :u16                            # CRC-16/MCRF4XX (see note for input bytes)
+    if (incompat_flags & MAVLINK_V2_INCOMPAT_FLAG_SIGNED) != 0:
+        signature :MavlinkV2Signature


### PR DESCRIPTION
## Summary

Five new `.bgn` example formats, +205 lines total.

- **`example/dtls_record.bgn`** — DTLS 1.2 record-layer envelope (RFC 6347 §4.1): 13B fixed header (ContentType + DTLSVersion + epoch + 48-bit sequence_number + length) + length-prefixed fragment. `DTLSContentType` / `DTLSVersion` enums shared with TLS where compatible plus heartbeat (24).
- **`example/filesystem/mbr.bgn`** — Classic MBR sector: 446B bootstrap area + 4×16B partition entries with CHS (24-bit packed: head | cyl_high:2 | sector:6 | cyl_low) and LBA dual-addressing + 0xAA55 boot signature; partition entry exposed top-level.
- **`example/filesystem/gpt.bgn`** — GPT primary header at LBA1 (92B per UEFI 2.10 §5.3.2) + `GptPartitionEntry` (128B per §5.3.3); `GPT_SIGNATURE` constant for "EFI PART".
- **`example/net/mavlink_v2.bgn`** — MAVLink v2 packet framing: STX 0xFD + len + incompat/compat flags + seq + sysid + compid + msgid u24 + payload + checksum + optional 13B signature (link_id u8 + timestamp u48 + sig [6]u8) gated by `incompat_flags` bit 0.
- **`example/media/ac3.bgn`** — AC-3 (Dolby Digital) syncframe header per ATSC A/52:2018 §5.3-5.4: syncinfo (syncword 0x0B77 + crc1 + fscod + frmsizecod) + bsi with conditional cmixlev/surmixlev/dsurmod by acmod + dual-mono ch2 duplicate block when acmod==0 + addbsi extension.

Follow-up batch after #363.

## Test plan

- [ ] \`src2json --no-color\` parses each new file cleanly with zero warnings
- [ ] \`python script/build.py\` green